### PR TITLE
Laravel 8.x is supported now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,19 +26,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           - php: '7.3'
             setup: basic
             coverage: no
-            laravel: '~5.6.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~5.7.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~5.8.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '^6.0'
+            laravel: '^7.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Install specific laravel version
         if: matrix.laravel != 'default'
-        run: composer require --dev --update-with-dependencies --prefer-dist --no-suggest --ansi laravel/laravel "${{ matrix.laravel }}"
+        run: composer require --dev --update-with-all-dependencies --prefer-dist --no-suggest --ansi laravel/laravel "${{ matrix.laravel }}"
 
       - name: Show most important packages versions
         run: composer info | grep -e laravel -e phpunit/phpunit -e phpstan -e guzzle

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         run: composer require --dev --update-with-dependencies --prefer-dist --no-suggest --ansi laravel/laravel "${{ matrix.laravel }}"
 
       - name: Show most important packages versions
-        run: composer info | grep -e laravel -e phpunit -e phpstan
+        run: composer info | grep -e laravel -e phpunit/phpunit -e phpstan -e guzzle
 
       - name: Execute tests
         if: matrix.coverage != 'yes'

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ composer.lock
 /coverage
 clover-file
 .DS_Store
-.php_cs.cache
+*.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Laravel `8.x` is supported now
+- Guzzle 7 (`guzzlehttp/guzzle`) is supported now
 - Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)
 - CI completely moved from "Travis CI" to "Github Actions" _(travis builds disabled)_
 - Minimal required PHP version now is `7.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## UNRELEASED
+## v2.3.0
 
 ### Changed
 
+- Laravel `8.x` is supported now
+- Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)
 - CI completely moved from "Travis CI" to "Github Actions" _(travis builds disabled)_
 - Minimal required PHP version now is `7.2`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM php:7.2.5-alpine
+FROM php:7.3.5-alpine
 
 ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:1.10.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.10 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.1 1>/dev/null \
+    && pecl install xdebug-2.9.6 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
     && composer global require 'hirak/prestissimo' --no-interaction --no-suggest --prefer-dist \

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,8 @@
 # Makefile readme (ru): <http://linux.yaroslavl.ru/docs/prog/gnu_make_3-79_russian_manual.html>
 # Makefile readme (en): <https://www.gnu.org/software/make/manual/html_node/index.html#SEC_Contents>
 
-dc_bin := $(shell command -v docker-compose 2> /dev/null)
-
 SHELL = /bin/sh
-RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)" app
+RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)"
 
 .PHONY : help build latest install lowest test test-cover clean
 .DEFAULT_GOAL : help
@@ -16,25 +14,25 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build docker images, required for current package environment
-	$(dc_bin) build
+	docker-compose build
 
 latest: clean ## Install latest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
 
 install: clean ## Install regular php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction --no-suggest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction --no-suggest
 
 lowest: clean ## Install lowest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
 
 test: ## Execute php tests and linters
-	$(dc_bin) run $(RUN_APP_ARGS) composer test
+	docker-compose run $(RUN_APP_ARGS) app composer test
 
 test-cover: ## Execute php tests with coverage
-	$(dc_bin) run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
+	docker-compose run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
-	$(dc_bin) run -e "PS1=\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]" $(RUN_APP_ARGS) sh
+	docker-compose run $(RUN_APP_ARGS) app sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         "php": "^7.2",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.0",
-        "illuminate/support": "^5.4 || ~6.0 || ~7.0",
-        "illuminate/contracts": "^5.4 || ~6.0 || ~7.0",
-        "illuminate/notifications": "^5.4 || ~6.0 || ~7.0"
+        "illuminate/support": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/notifications": "~6.0 || ~7.0 || ~8.0"
     },
     "require-dev": {
-        "laravel/laravel": "^5.4 || ~6.0 || ~7.0",
-        "phpunit/phpunit": "~7.5",
+        "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
+        "phpunit/phpunit": "^8.5.4 || ^9.3",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "~0.12"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0 || ~7.0",
         "illuminate/support": "~6.0 || ~7.0 || ~8.0",
         "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
         "illuminate/notifications": "~6.0 || ~7.0 || ~8.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      PS1: '\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]'
     volumes:
       - /etc/passwd:/etc/passwd:ro
       - /etc/group:/etc/group:ro

--- a/src/SmsPilotServiceProvider.php
+++ b/src/SmsPilotServiceProvider.php
@@ -22,7 +22,7 @@ class SmsPilotServiceProvider extends IlluminateServiceProvider
         $this->app
             ->when(SmsPilotChannel::class)
             ->needs(ApiClientInterface::class)
-            ->give(function (Container $app) {
+            ->give(static function (Container $app) {
                 /** @var ConfigRepository $config */
                 $config = $app->make(ConfigRepository::class);
 

--- a/tests/ApiClient/ApiClientTest.php
+++ b/tests/ApiClient/ApiClientTest.php
@@ -74,7 +74,7 @@ class ApiClientTest extends AbstractTestCase
     {
         $this->expectException(CannotSendMessage::class);
         $this->expectExceptionCode(666);
-        $this->expectExceptionMessageRegExp('/Error desc.*666/i');
+        $this->expectExceptionMessageMatches('/Error desc.*666/i');
 
         $client = new ApiClientMock('foo', 'bar', [
             new Response(200, [], '{"error":{"code":666,"description":"Error desc"}}'),
@@ -92,7 +92,7 @@ class ApiClientTest extends AbstractTestCase
     {
         $this->expectException(CannotSendMessage::class);
         $this->expectExceptionCode(0);
-        $this->expectExceptionMessageRegExp('/Unavailable.*code.*0/i');
+        $this->expectExceptionMessageMatches('/Unavailable.*code.*0/i');
 
         $client = new ApiClientMock('foo', 'bar', [
             new Response(200, [], '{"error":{"code":false,"description":false}}'),

--- a/tests/ApiClient/Responses/MessageSentResponseTest.php
+++ b/tests/ApiClient/Responses/MessageSentResponseTest.php
@@ -36,7 +36,7 @@ class MessageSentResponseTest extends AbstractTestCase
     public function testExceptionWithInvalidJsonPassedIntoConstructor(): void
     {
         $this->expectException(InvalidResponseException::class);
-        $this->expectExceptionMessageRegExp('~Cannot decode~i');
+        $this->expectExceptionMessageMatches('~Cannot decode~i');
 
         new MessageSentResponse(new Response(200, [], '{"foo":'));
     }

--- a/tests/SmsPilotChannelTest.php
+++ b/tests/SmsPilotChannelTest.php
@@ -48,7 +48,7 @@ class SmsPilotChannelTest extends AbstractTestCase
     public function testNotificationExceptionOnSenderWithoutRoute(): void
     {
         $this->expectException(MissingNotificationRouteException::class);
-        $this->expectExceptionMessageRegExp('~Missing notification route~i');
+        $this->expectExceptionMessageMatches('~Missing notification route~i');
 
         $api_client = new ApiClientMock('foo', 'bar');
         $channel    = new SmsPilotChannel($api_client);
@@ -64,7 +64,7 @@ class SmsPilotChannelTest extends AbstractTestCase
     public function testNotificationExceptionOnNotificationInvalidRoute(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('~must returns object with instance~i');
+        $this->expectExceptionMessageMatches('~must returns object with instance~i');
 
         $api_client = new ApiClientMock('foo', 'bar');
         $channel    = new SmsPilotChannel($api_client);


### PR DESCRIPTION
## Description

### Changed

- Laravel `8.x` is supported now
- Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
