### PR TITLE
Laravel 11 support was added

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,15 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.0', '8.1', '8.2']
+        php: ['8.1', '8.2', '8.3']
+        include:
+          - php: '8.1'
+            setup: [ basic, lowest ]
+            coverage: no
+            laravel: '^10.0'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -37,7 +42,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
@@ -68,7 +73,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           XDEBUG_MODE: coverage
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v3 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v4 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -81,7 +86,7 @@ jobs: # Docs: <https://git.io/JvxXE>
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Laravel `11.x` support
+
+### Changed
+
+- Minimal Laravel version now is `10.0`
+- Version of `composer` in docker container updated up to `2.7.6`
+- Updated dev dependencies
+
 ## v2.5.0
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM php:8.0-alpine
+FROM php:8.3-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.5.4 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.7.6 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps linux-headers autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.2.0 1>/dev/null \
+    && pecl install xdebug-3.3.0 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.0 || ~7.0",
-        "illuminate/support": "~9.0",
-        "illuminate/contracts": "~9.0",
-        "illuminate/notifications": "~9.1"
+        "guzzlehttp/guzzle": "~7.0",
+        "illuminate/support": "~10.0 || ~11.0",
+        "illuminate/contracts": "~10.0 || ~11.0",
+        "illuminate/notifications": "~10.0 || ~11.0"
     },
     "require-dev": {
-        "laravel/laravel": "~9.0",
-        "phpunit/phpunit": "~9.6.3",
-        "mockery/mockery": "^1.5.1",
-        "phpstan/phpstan": "^1.9"
+        "laravel/laravel": "~10.0 || ~11.0",
+        "phpunit/phpunit": "^10.5",
+        "mockery/mockery": "^1.6.5",
+        "phpstan/phpstan": "^1.10.66"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,4 @@
 parameters:
   level: 'max'
-  checkGenericClassInNonGenericObjectType: false
   paths:
     - src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="./tests/bootstrap.php" colors="true"
-         forceCoversAnnotation="true">
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <exclude>
-            <directory>./vendor</directory>
-        </exclude>
-        <report>
-            <clover outputFile="./coverage/clover.xml"/>
-            <text outputFile="php://stdout"/>
-            <xml outputDirectory="./coverage/xml"/>
-        </report>
-    </coverage>
-    <testsuites>
-        <testsuite name="Unit">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <env name="SMS_PILOT_API_KEY" value="apikey_for_test_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"/>
-        <env name="SMS_PILOT_SENDER_NAME" value="TestsSenderName"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="./tests/bootstrap.php" colors="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true">
+  <coverage>
+    <report>
+      <clover outputFile="./coverage/clover.xml"/>
+      <text outputFile="php://stdout"/>
+      <xml outputDirectory="./coverage/xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="SMS_PILOT_API_KEY" value="apikey_for_test_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"/>
+    <env name="SMS_PILOT_SENDER_NAME" value="TestsSenderName"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/src/Messages/SmsPilotMessage.php
+++ b/src/Messages/SmsPilotMessage.php
@@ -7,6 +7,9 @@ namespace AvtoDev\SmsPilotNotifications\Messages;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
+/**
+ * @implements Arrayable<string, mixed>
+ */
 class SmsPilotMessage implements Jsonable, Arrayable
 {
     /**

--- a/tests/ApiClient/ApiClientTest.php
+++ b/tests/ApiClient/ApiClientTest.php
@@ -12,7 +12,7 @@ use AvtoDev\SmsPilotNotifications\Exceptions\HttpRequestException;
 use AvtoDev\SmsPilotNotifications\Exceptions\InvalidResponseException;
 
 /**
- * @covers \AvtoDev\SmsPilotNotifications\ApiClient\ApiClient<extended>
+ * @covers \AvtoDev\SmsPilotNotifications\ApiClient\ApiClient
  */
 class ApiClientTest extends AbstractTestCase
 {

--- a/tests/ApiClient/Responses/MessageSentResponseTest.php
+++ b/tests/ApiClient/Responses/MessageSentResponseTest.php
@@ -11,7 +11,7 @@ use AvtoDev\SmsPilotNotifications\Exceptions\InvalidResponseException;
 use AvtoDev\SmsPilotNotifications\ApiClient\Responses\MessageSentResponse;
 
 /**
- * @covers \AvtoDev\SmsPilotNotifications\ApiClient\Responses\MessageSentResponse<extended>
+ * @covers \AvtoDev\SmsPilotNotifications\ApiClient\Responses\MessageSentResponse
  */
 class MessageSentResponseTest extends AbstractTestCase
 {

--- a/tests/Messages/SmsPilotMessageTest.php
+++ b/tests/Messages/SmsPilotMessageTest.php
@@ -8,7 +8,7 @@ use AvtoDev\SmsPilotNotifications\Tests\AbstractTestCase;
 use AvtoDev\SmsPilotNotifications\Messages\SmsPilotMessage;
 
 /**
- * @covers \AvtoDev\SmsPilotNotifications\Messages\SmsPilotMessage<extended>
+ * @covers \AvtoDev\SmsPilotNotifications\Messages\SmsPilotMessage
  */
 class SmsPilotMessageTest extends AbstractTestCase
 {

--- a/tests/Messages/SmsPilotSentMessageTest.php
+++ b/tests/Messages/SmsPilotSentMessageTest.php
@@ -8,7 +8,7 @@ use AvtoDev\SmsPilotNotifications\Tests\AbstractTestCase;
 use AvtoDev\SmsPilotNotifications\Messages\SmsPilotSentMessage;
 
 /**
- * @covers \AvtoDev\SmsPilotNotifications\Messages\SmsPilotSentMessage<extended>
+ * @covers \AvtoDev\SmsPilotNotifications\Messages\SmsPilotSentMessage
  */
 class SmsPilotSentMessageTest extends AbstractTestCase
 {

--- a/tests/SmsPilotChannelTest.php
+++ b/tests/SmsPilotChannelTest.php
@@ -17,7 +17,7 @@ use AvtoDev\SmsPilotNotifications\ApiClient\Responses\MessageSentResponse;
 use AvtoDev\SmsPilotNotifications\Exceptions\MissingNotificationRouteException;
 
 /**
- * @covers \AvtoDev\SmsPilotNotifications\SmsPilotChannel<extended>
+ * @covers \AvtoDev\SmsPilotNotifications\SmsPilotChannel
  */
 class SmsPilotChannelTest extends AbstractTestCase
 {

--- a/tests/SmsPilotServiceProviderTest.php
+++ b/tests/SmsPilotServiceProviderTest.php
@@ -8,7 +8,7 @@ use AvtoDev\SmsPilotNotifications\SmsPilotChannel;
 use AvtoDev\SmsPilotNotifications\ApiClient\ApiClient;
 
 /**
- * @covers \AvtoDev\SmsPilotNotifications\SmsPilotServiceProvider<extended>
+ * @covers \AvtoDev\SmsPilotNotifications\SmsPilotServiceProvider
  */
 class SmsPilotServiceProviderTest extends AbstractTestCase
 {


### PR DESCRIPTION
## Description

Laravel 11 support 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Unreleased

### Added

- Laravel `11.x` support

### Changed

- Minimal Laravel version now is `10.0`
- Version of `composer` in docker container updated up to `2.7.6`
- Updated dev dependencies